### PR TITLE
refactor verse layout handling to improve verse rendering logic

### DIFF
--- a/lib/ui/home/panel_area/bible_panel/bible_chapter.dart
+++ b/lib/ui/home/panel_area/bible_panel/bible_chapter.dart
@@ -60,12 +60,34 @@ class _BibleChapterState extends State<BibleChapter> {
           );
         }
 
-        final verses = widget.verseLayout == VerseLayout.versePerLine
-            ? Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: verseLines.map((v) => buildUsfm([v])).toList(),
-              )
-            : buildUsfm(verseLines);
+        final Widget verses;
+
+        if (widget.verseLayout == VerseLayout.versePerLine) {
+          List<Widget> listVerses = [];
+          List<UsfmLine> lines = [];
+
+          int? verseNumber;
+
+          for (UsfmLine line in verseLines) {
+            if (verseNumber == null || verseNumber == line.verse) {
+              lines.add(line);
+            } else {
+              listVerses.add(buildUsfm(lines));
+              lines = [];
+              lines.add(line);
+            }
+            verseNumber = line.verse;
+          }
+
+          listVerses.add(buildUsfm(lines));
+
+          verses = Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: listVerses,
+          );
+        } else {
+          verses = buildUsfm(verseLines);
+        }
 
         return Container(
           width: double.infinity,


### PR DESCRIPTION
Handle proper rendering of verse number for multi-lines verses

before the fix:
<img width="912" height="897" alt="Screenshot 2026-05-13 at 11 57 29 PM" src="https://github.com/user-attachments/assets/ce5fb78a-482c-4069-a88b-72fe3fbad1eb" />

after the fix:
<img width="912" height="897" alt="Screenshot 2026-05-13 at 11 57 43 PM" src="https://github.com/user-attachments/assets/f2a17845-3ea1-4b40-be1a-3f86af3ac589" />
