### PR TITLE
separate gloss language from ui language

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -10,6 +10,7 @@
     "emailCopied": "تم نسخ البريد الإلكتروني",
     "settings": "الإعدادات",
     "language": "اللغة",
+    "glossLanguage": "لغة التفسير",
     "currentLanguage": "العربية",
     "textSize": "حجم النص",
     "hebrewTextSize": "العبرية",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -40,6 +40,10 @@
   "@language": {
     "description": "Settings menu item to change the app language"
   },
+  "glossLanguage": "Gloss Language",
+  "@glossLanguage": {
+    "description": "Settings menu item to change the gloss (translation) language"
+  },
   "currentLanguage": "English",
   "@currentLanguage": {
     "description": "The name of the language for this locale"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -10,6 +10,7 @@
     "emailCopied": "Correo electrónico copiado",
     "settings": "Ajustes",
     "language": "Idioma",
+    "glossLanguage": "Idioma del glosario",
     "currentLanguage": "Español",
     "textSize": "Tamaño del texto",
     "hebrewTextSize": "Hebreo",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -10,6 +10,7 @@
     "emailCopied": "Adresse e-mail copiée",
     "settings": "Paramètres",
     "language": "Langue",
+    "glossLanguage": "Langue du glossaire",
     "currentLanguage": "Français",
     "textSize": "Taille du texte",
     "hebrewTextSize": "Hébreu",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -164,6 +164,12 @@ abstract class AppLocalizations {
   /// **'Language'**
   String get language;
 
+  /// Settings menu item to change the gloss (translation) language
+  ///
+  /// In en, this message translates to:
+  /// **'Gloss Language'**
+  String get glossLanguage;
+
   /// The name of the language for this locale
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -39,6 +39,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get language => 'اللغة';
 
   @override
+  String get glossLanguage => 'لغة التفسير';
+
+  @override
   String get currentLanguage => 'العربية';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -39,6 +39,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get language => 'Language';
 
   @override
+  String get glossLanguage => 'Gloss Language';
+
+  @override
   String get currentLanguage => 'English';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -39,6 +39,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get language => 'Idioma';
 
   @override
+  String get glossLanguage => 'Idioma del glosario';
+
+  @override
   String get currentLanguage => 'Español';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -39,6 +39,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get language => 'Langue';
 
   @override
+  String get glossLanguage => 'Langue du glossaire';
+
+  @override
   String get currentLanguage => 'Français';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -39,6 +39,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get language => 'Idioma';
 
   @override
+  String get glossLanguage => 'Idioma do glossário';
+
+  @override
   String get currentLanguage => 'Português';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -10,6 +10,7 @@
     "emailCopied": "E-mail copiado",
     "settings": "Configurações",
     "language": "Idioma",
+    "glossLanguage": "Idioma do glossário",
     "currentLanguage": "Português",
     "textSize": "Tamanho do texto",
     "hebrewTextSize": "Hebraico",

--- a/lib/services/gloss/gloss_database.dart
+++ b/lib/services/gloss/gloss_database.dart
@@ -5,6 +5,13 @@ import 'package:gbt/l10n/app_languages.dart';
 import 'package:gbt/services/files/file_service.dart';
 import 'package:gbt/services/service_locator.dart';
 
+class GlossResource {
+  final String name;
+  final String code;
+
+  const GlossResource({required this.name, required this.code});
+}
+
 class GlossDatabase {
   final _fileService = getIt<FileService>();
 
@@ -13,6 +20,16 @@ class GlossDatabase {
 
   String getDbFilename(String langCode) {
     return AppLanguages.getConfig(langCode).glossFilename;
+  }
+
+  List<GlossResource> getGlossResources() {
+    return const [
+      GlossResource(name: 'English', code: 'eng'),
+      GlossResource(name: 'Español', code: 'spa'),
+      GlossResource(name: 'Français', code: 'fra'),
+      GlossResource(name: 'Português', code: 'por'),
+      GlossResource(name: 'العربية', code: 'are'),
+    ];
   }
 
   Future<bool> glossDbExists(String langCode) async {

--- a/lib/services/gloss/gloss_database.dart
+++ b/lib/services/gloss/gloss_database.dart
@@ -1,7 +1,6 @@
 import 'dart:developer';
 import 'package:database_builder/database_builder.dart'; // Assuming this is where GlossSchema lives
 import 'package:sqflite/sqflite.dart';
-import 'package:gbt/l10n/app_languages.dart';
 import 'package:gbt/services/files/file_service.dart';
 import 'package:gbt/services/service_locator.dart';
 
@@ -19,7 +18,7 @@ class GlossDatabase {
   String _currentLangCode = '';
 
   String getDbFilename(String langCode) {
-    return AppLanguages.getConfig(langCode).glossFilename;
+    return '$langCode.db';
   }
 
   List<GlossResource> getGlossResources() {
@@ -38,7 +37,7 @@ class GlossDatabase {
   }
 
   Future<void> initDb(String langCode) async {
-    if (langCode == 'en' || _currentLangCode == langCode) {
+    if (langCode == 'eng' || _currentLangCode == langCode) {
       return;
     }
 

--- a/lib/services/gloss/gloss_service.dart
+++ b/lib/services/gloss/gloss_service.dart
@@ -19,6 +19,9 @@ class GlossService {
   final _englishGlossDb = EnglishDatabase();
   final _glossDb = GlossDatabase();
 
+  /// The list of available gloss resources (languages).
+  List<GlossResource> get glossResources => _glossDb.getGlossResources();
+
   Future<void> init() async {
     await _englishGlossDb.init();
     final langCode = _settings.locale.languageCode;

--- a/lib/services/gloss/gloss_service.dart
+++ b/lib/services/gloss/gloss_service.dart
@@ -1,8 +1,6 @@
 import 'dart:developer';
-import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
-import 'package:gbt/l10n/app_localizations.dart';
 import 'package:gbt/services/resources/remote_asset_service.dart';
 import 'package:gbt/services/download/cancel_token.dart';
 import 'package:gbt/services/download/download.dart';
@@ -24,19 +22,17 @@ class GlossService {
 
   Future<void> init() async {
     await _englishGlossDb.init();
-    final langCode = _settings.locale.languageCode;
-    if (langCode != 'en') {
+    final langCode = _settings.glossLang;
+    if (langCode != 'eng') {
       await _glossDb.initDb(langCode);
     }
   }
 
-  /// Downloads the gloss database for the given locale.
   Future<void> downloadGlosses(
-    Locale locale, {
+    String langCode, {
     ValueChanged<double>? onProgress,
     CancelToken? cancelToken,
   }) async {
-    final langCode = locale.languageCode;
     final asset = _assetService.getGlossAsset(langCode);
 
     log('Downloading glosses for $langCode from ${asset.remoteUrl}');
@@ -57,18 +53,15 @@ class GlossService {
   }
 
   Future<String?> glossForId({
-    required Locale locale,
     required int wordId,
-    void Function(Locale)? onDatabaseMissing,
+    void Function(String)? onDatabaseMissing,
   }) async {
-    final glossLocale = _settings.locale;
+    final langCode = _settings.glossLang;
 
     // 1. If English, use English DB directly
-    if (!_isDownloadableLanguage(glossLocale)) {
+    if (langCode == 'eng') {
       return await _englishGlossDb.getGloss(wordId);
     }
-
-    final langCode = glossLocale.languageCode;
 
     // 2. Check if localized DB exists
     final dbExists = await _glossDb.glossDbExists(langCode);
@@ -80,22 +73,18 @@ class GlossService {
       return localizedGloss ?? await _englishGlossDb.getGloss(wordId);
     } else {
       // 4. Trigger UI callback to prompt download
-      onDatabaseMissing?.call(Locale(langCode));
+      onDatabaseMissing?.call(langCode);
       // Fallback to English while waiting
       return await _englishGlossDb.getGloss(wordId);
     }
   }
 
-  bool _isDownloadableLanguage(Locale locale) {
-    if (locale.languageCode == 'en') return false;
-    return AppLocalizations.supportedLocales.any(
-      (l) => l.languageCode == locale.languageCode,
-    );
+  Future<bool> glossesExists(String langCode) async {
+    if (langCode == 'eng') return true;
+    return await _glossDb.glossDbExists(langCode);
   }
 
-  Future<bool> glossesExists(Locale selectedLocale) async {
-    final langCode = selectedLocale.languageCode;
-    if (langCode == 'en') return true;
-    return await _glossDb.glossDbExists(langCode);
+  Future<bool> currentGlossExists() async {
+    return await glossesExists(_settings.glossLang);
   }
 }

--- a/lib/services/gloss/gloss_service.dart
+++ b/lib/services/gloss/gloss_service.dart
@@ -83,8 +83,4 @@ class GlossService {
     if (langCode == 'eng') return true;
     return await _glossDb.glossDbExists(langCode);
   }
-
-  Future<bool> currentGlossExists() async {
-    return await glossesExists(_settings.glossLang);
-  }
 }

--- a/lib/services/resources/remote_asset_service.dart
+++ b/lib/services/resources/remote_asset_service.dart
@@ -55,9 +55,8 @@ class RemoteAssetService {
 
   // --- GLOSS ASSETS ---
 
-  /// Returns the asset config for a gloss database.
   RemoteAsset getGlossAsset(String langCode) {
-    final filename = AppLanguages.getConfig(langCode).glossFilename;
+    final filename = '$langCode.db';
 
     return RemoteAsset(
       remoteUrl: '$_baseHost/glosses/v1/$filename.zip',

--- a/lib/services/resources/resource_service.dart
+++ b/lib/services/resources/resource_service.dart
@@ -1,19 +1,15 @@
 import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:gbt/services/bible/bible_service.dart';
-import 'package:gbt/services/gloss/gloss_service.dart';
 import 'package:gbt/services/service_locator.dart';
 import 'package:gbt/services/download/cancel_token.dart';
 
 class ResourceService {
   final _bibleService = getIt<BibleService>();
-  final _glossService = getIt<GlossService>();
 
   Future<bool> areResourcesDownloaded(Locale locale) async {
     if (locale.languageCode == 'en') return true;
-    final bibleExists = await _bibleService.bibleExists(locale);
-    final glossExists = await _glossService.glossesExists(locale);
-    return bibleExists && glossExists;
+    return await _bibleService.bibleExists(locale);
   }
 
   Future<void> downloadResources(
@@ -21,39 +17,23 @@ class ResourceService {
     required ValueNotifier<double> progressNotifier,
     required CancelToken cancelToken,
   }) async {
-    final needGloss = !await _glossService.glossesExists(locale);
     final needBible = !await _bibleService.bibleExists(locale);
 
-    double tasksToRun = (needGloss ? 1.0 : 0.0) + (needBible ? 1.0 : 0.0);
-    double tasksCompleted = 0;
+    if (!needBible) {
+      progressNotifier.value = 1.0;
+      return;
+    }
 
     void updateProgress(double fileProgress) {
-      if (tasksToRun == 0) {
-        progressNotifier.value = 1.0;
-        return;
-      }
-      progressNotifier.value =
-          (tasksCompleted / tasksToRun) + (fileProgress / tasksToRun);
+      progressNotifier.value = fileProgress;
     }
 
-    if (needGloss) {
-      await _glossService.downloadGlosses(
-        locale,
-        cancelToken: cancelToken,
-        onProgress: updateProgress,
-      );
-      tasksCompleted++;
-    }
-
-    if (needBible) {
-      updateProgress(0.0);
-      await _bibleService.downloadBible(
-        locale,
-        cancelToken: cancelToken,
-        onProgress: updateProgress,
-      );
-      tasksCompleted++;
-    }
+    updateProgress(0.0);
+    await _bibleService.downloadBible(
+      locale,
+      cancelToken: cancelToken,
+      onProgress: updateProgress,
+    );
     progressNotifier.value = 1.0;
   }
 }

--- a/lib/services/settings/user_settings.dart
+++ b/lib/services/settings/user_settings.dart
@@ -19,6 +19,7 @@ class UserSettings {
   static const _bibleFontScaleKey = 'bibleFontScale';
   static const _wordDetailsFontScaleKey = 'wordDetailsFontScale';
   static const _localeKey = 'locale';
+  static const _glossLangKey = 'glossLang';
   static const _isHebrewSearchKey = 'isHebrewSearch';
   static const _useSystemKeyboardKey = 'useSystemKeyboard';
   static const _currentBible = 'currentBible';
@@ -90,6 +91,14 @@ class UserSettings {
     } else {
       await _prefs.setString(_localeKey, localeCode);
     }
+  }
+
+  String get glossLang {
+    return _prefs.getString(_glossLangKey) ?? 'eng';
+  }
+
+  Future<void> setGlossLang(String code) async {
+    await _prefs.setString(_glossLangKey, code);
   }
 
   bool get isHebrewSearch {

--- a/lib/ui/common/resource_ui_helper.dart
+++ b/lib/ui/common/resource_ui_helper.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gbt/l10n/app_localizations.dart';
 import 'package:gbt/services/download/cancel_token.dart';
+import 'package:gbt/services/gloss/gloss_service.dart';
 import 'package:gbt/services/resources/resource_service.dart';
 import 'package:gbt/services/service_locator.dart';
 import 'package:gbt/ui/common/download_progress_dialog.dart';
@@ -54,6 +55,61 @@ class ResourceUIHelper {
         task: (progress, token) => resourceService.downloadResources(
           targetLocale,
           progressNotifier: progress,
+          cancelToken: token,
+        ),
+      );
+      return true;
+    } catch (e) {
+      if (context.mounted && e is! DownloadCanceledException) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text("${l10n.downloadFailed}: $e")));
+      }
+      return false;
+    }
+  }
+
+  static Future<bool> ensureGloss(
+    BuildContext context,
+    String langCode,
+  ) async {
+    final glossService = getIt<GlossService>();
+    if (await glossService.glossesExists(langCode)) return true;
+
+    if (!context.mounted) return false;
+    final l10n = AppLocalizations.of(context)!;
+
+    // 1. Show Prompt
+    final shouldDownload =
+        await showDialog<bool>(
+          context: context,
+          barrierDismissible: false,
+          builder: (context) => AlertDialog(
+            content: Text(l10n.downloadResourcesMessage),
+            actions: [
+              TextButton(
+                child: Text(l10n.cancel),
+                onPressed: () => Navigator.pop(context, false),
+              ),
+              FilledButton(
+                child: Text(l10n.download),
+                onPressed: () => Navigator.pop(context, true),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+
+    if (!shouldDownload) return false;
+
+    // 2. Show Download Dialog
+    try {
+      if (!context.mounted) throw Exception('Context not mounted');
+      await DownloadProgressDialog.show(
+        context: context,
+        task: (progress, token) => glossService.downloadGlosses(
+          langCode,
+          onProgress: (p) => progress.value = p,
           cancelToken: token,
         ),
       );

--- a/lib/ui/home/panel_area/hebrew_greek_panel/chapter.dart
+++ b/lib/ui/home/panel_area/hebrew_greek_panel/chapter.dart
@@ -249,11 +249,9 @@ class HebrewGreekChapterState extends State<HebrewGreekChapter>
                           color: Theme.of(context).colorScheme.onInverseSurface,
                         ),
                         popupWordProvider: (wordId) {
-                          final locale = Localizations.localeOf(context);
                           return manager.getPopupTextForId(
-                            locale,
                             wordId,
-                            (locale) => _handleMissingResources(locale),
+                            (langCode) => _handleMissingGloss(langCode),
                           );
                         },
                         onPopupShown: _ensurePopupIsVisible,
@@ -330,15 +328,15 @@ class HebrewGreekChapterState extends State<HebrewGreekChapter>
     });
   }
 
-  Future<void> _handleMissingResources(Locale locale) async {
+  Future<void> _handleMissingGloss(String langCode) async {
     // Use the shared helper logic
-    final success = await ResourceUIHelper.ensureResources(context, locale);
+    final success = await ResourceUIHelper.ensureGloss(context, langCode);
 
     if (!success && mounted) {
       // If they clicked "Cancel" or download failed,
       // tell the manager to stop trying to load localized glosses
       // for this session so they aren't prompted on every single tap.
-      manager.setLanguageToEnglish(locale);
+      manager.setGlossToEnglish();
     } else if (success && mounted) {
       // Refresh the UI so the words show the newly downloaded glosses
       setState(() {});

--- a/lib/ui/home/panel_area/hebrew_greek_panel/chapter_manager.dart
+++ b/lib/ui/home/panel_area/hebrew_greek_panel/chapter_manager.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:gbt/app_state.dart';
 import 'package:gbt/common/word.dart';
-import 'package:gbt/services/bible/bible_service.dart';
-import 'package:gbt/services/download/cancel_token.dart';
 import 'package:gbt/services/gloss/gloss_service.dart';
 import 'package:gbt/services/hebrew_greek/database.dart';
 import 'package:gbt/services/reading_session/rs_manager.dart';
@@ -12,7 +9,6 @@ import 'package:gbt/services/settings/user_settings.dart';
 class HebrewGreekChapterManager {
   final _hebrewGreekDb = getIt<HebrewGreekDatabase>();
   final _glossService = getIt<GlossService>();
-  final _bibleService = getIt<BibleService>();
   final _settings = getIt<UserSettings>();
   final _rsmanager = getIt<ReadingSessionManager>();
 
@@ -73,71 +69,18 @@ class HebrewGreekChapterManager {
   }
 
   Future<String?> getPopupTextForId(
-    Locale uiLocale,
     int wordId,
-    void Function(Locale)? onGlossDownloadNeeded,
+    void Function(String)? onGlossDownloadNeeded,
   ) async {
     return _glossService.glossForId(
-      locale: uiLocale,
       wordId: wordId,
       onDatabaseMissing: onGlossDownloadNeeded,
     );
   }
 
-  // Called from the UI when user agrees to download.
-  Future<void> downloadResources(
-    Locale locale, {
-    required ValueNotifier<double> progressNotifier,
-    required CancelToken cancelToken,
-  }) async {
-    // Reuse the exact same logic as SettingsManager
-    // 1. Determine tasks
-    final needGloss = !await _glossService.glossesExists(locale);
-    final needBible = !await _bibleService.bibleExists(locale);
-
-    int tasksToRun = (needGloss ? 1 : 0) + (needBible ? 1 : 0);
-    int tasksCompleted = 0;
-
-    void updateProgress(double fileProgress) {
-      if (tasksToRun == 0) {
-        progressNotifier.value = 1.0;
-        return;
-      }
-      final overall =
-          (tasksCompleted / tasksToRun) + (fileProgress / tasksToRun);
-      progressNotifier.value = overall;
-    }
-
-    // 2. Glosses
-    if (needGloss) {
-      if (cancelToken.isCancelled) return;
-      await _glossService.downloadGlosses(
-        locale,
-        cancelToken: cancelToken,
-        onProgress: updateProgress,
-      );
-      tasksCompleted++;
-    }
-
-    // 3. Bible
-    if (needBible) {
-      if (cancelToken.isCancelled) return;
-      updateProgress(0.0);
-      await _bibleService.downloadBible(
-        locale,
-        cancelToken: cancelToken,
-        onProgress: updateProgress,
-      );
-      tasksCompleted++;
-    }
-
-    progressNotifier.value = 1.0;
-  }
-
   // Called from the UI when user wants to use English instead of downloading.
-  Future<void> setLanguageToEnglish(Locale originalLocale) async {
-    await _settings.setLocale('en');
-    getIt<AppState>().init();
+  Future<void> setGlossToEnglish() async {
+    await _settings.setGlossLang('eng');
   }
 
   String getVerseText(int verse) {

--- a/lib/ui/home/word_details_dialog/dialog_manager.dart
+++ b/lib/ui/home/word_details_dialog/dialog_manager.dart
@@ -1,7 +1,4 @@
-import 'dart:ui';
-
 import 'package:flutter/foundation.dart';
-import 'package:flutter/painting.dart';
 import 'package:gbt/services/gloss/gloss_service.dart';
 import 'package:gbt/services/hebrew_greek/database.dart';
 import 'package:gbt/services/lexicon/database.dart';
@@ -17,20 +14,17 @@ class WordDetailsDialogManager extends ChangeNotifier {
   WordDetails? wordDetails;
   List<LexiconMeaning> lexiconMeanings = [];
 
-  Future<void> init(Locale locale, int wordId) async {
-    wordDetails = await _getWordDetails(locale, wordId);
+  Future<void> init(int wordId) async {
+    wordDetails = await _getWordDetails(wordId);
     lexiconMeanings = await _lexiconDb.getMeaningsForStrongs(
       wordDetails!.strongsCode,
     );
     notifyListeners();
   }
 
-  Future<WordDetails> _getWordDetails(Locale uiLocale, int wordId) async {
+  Future<WordDetails> _getWordDetails(int wordId) async {
     final word = await _hebrewGreekDb.getWordForId(wordId);
-    final gloss = await _glossService.glossForId(
-      locale: uiLocale,
-      wordId: wordId,
-    );
+    final gloss = await _glossService.glossForId(wordId: wordId);
     final (strongs, grammar) =
         await _hebrewGreekDb.getStrongsAndGrammar(wordId) ?? ('', '');
     return WordDetails(

--- a/lib/ui/home/word_details_dialog/word_details_dialog.dart
+++ b/lib/ui/home/word_details_dialog/word_details_dialog.dart
@@ -28,8 +28,7 @@ class _WordDetailsDialogState extends State<WordDetailsDialog> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final locale = Localizations.localeOf(context);
-    manager.init(locale, widget.wordId);
+    manager.init(widget.wordId);
     // Note: Styles are now defined inside the build method to react to scaling
   }
 

--- a/lib/ui/settings/settings_manager.dart
+++ b/lib/ui/settings/settings_manager.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:gbt/app_state.dart';
 import 'package:gbt/l10n/app_languages.dart';
+import 'package:gbt/services/gloss/gloss_database.dart';
+import 'package:gbt/services/gloss/gloss_service.dart';
 import 'package:gbt/services/service_locator.dart';
 import 'package:gbt/services/settings/user_settings.dart';
 
@@ -32,6 +34,29 @@ class SettingsManager extends ChangeNotifier {
   Future<void> setLocale(Locale selectedLocale) async {
     await _settings.setLocale(selectedLocale.languageCode);
     appState.init();
+    notifyListeners();
+  }
+
+  final _glossDb = getIt<GlossService>();
+
+  List<GlossResource> get glossResources {
+    return _glossDb.glossResources;
+  }
+
+  String get currentGlossLangCode => _settings.glossLang;
+
+  String get currentGlossLangName {
+    final code = currentGlossLangCode;
+    return glossResources
+        .firstWhere(
+          (r) => r.code == code,
+          orElse: () => glossResources.first,
+        )
+        .name;
+  }
+
+  Future<void> setGlossLang(String code) async {
+    await _settings.setGlossLang(code);
     notifyListeners();
   }
 

--- a/lib/ui/settings/settings_page.dart
+++ b/lib/ui/settings/settings_page.dart
@@ -103,12 +103,29 @@ class _SettingsPageState extends State<SettingsPage> {
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
                 onTap: () async {
+                  final previousCode = manager.currentGlossLangCode;
                   final selected = await _chooseGlossLanguage();
                   if (selected == null ||
-                      selected.code == manager.currentGlossLangCode) {
+                      selected.code == previousCode) {
                     return;
                   }
+
+                  // Immediately set so the UI reflects the selection
                   await manager.setGlossLang(selected.code);
+
+                  // English is built-in, no download needed
+                  if (selected.code == 'eng') return;
+                  if (!context.mounted) return;
+
+                  final success = await ResourceUIHelper.ensureGloss(
+                    context,
+                    selected.code,
+                  );
+
+                  if (!success && context.mounted) {
+                    // Revert if they cancelled or it failed
+                    await manager.setGlossLang(previousCode);
+                  }
                 },
               ),
 

--- a/lib/ui/settings/settings_page.dart
+++ b/lib/ui/settings/settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gbt/l10n/app_languages.dart';
 import 'package:gbt/l10n/app_localizations.dart';
+import 'package:gbt/services/gloss/gloss_database.dart';
 import 'package:gbt/ui/common/resource_ui_helper.dart';
 import 'package:gbt/services/settings/user_settings.dart';
 
@@ -27,6 +28,24 @@ class _SettingsPageState extends State<SettingsPage> {
             return SimpleDialogOption(
               onPressed: () => Navigator.pop(context, Locale(config.code)),
               child: Text(config.nativeName, style: textStyle),
+            );
+          }).toList(),
+        );
+      },
+    );
+  }
+
+  Future<GlossResource?> _chooseGlossLanguage() async {
+    return await showDialog<GlossResource>(
+      context: context,
+      builder: (BuildContext context) {
+        final textStyle = Theme.of(context).textTheme.bodyLarge;
+        return SimpleDialog(
+          title: Text(AppLocalizations.of(context)!.glossLanguage),
+          children: manager.glossResources.map((resource) {
+            return SimpleDialogOption(
+              onPressed: () => Navigator.pop(context, resource),
+              child: Text(resource.name, style: textStyle),
             );
           }).toList(),
         );
@@ -73,6 +92,23 @@ class _SettingsPageState extends State<SettingsPage> {
                     // Revert if they cancelled or it failed
                     await manager.setLocale(previousLocale);
                   }
+                },
+              ),
+
+              // Gloss Language
+              ListTile(
+                title: Text(l10n.glossLanguage),
+                trailing: Text(
+                  manager.currentGlossLangName,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                onTap: () async {
+                  final selected = await _chooseGlossLanguage();
+                  if (selected == null ||
+                      selected.code == manager.currentGlossLangCode) {
+                    return;
+                  }
+                  await manager.setGlossLang(selected.code);
                 },
               ),
 


### PR DESCRIPTION
## Description

Introduces a new app setting for gloss language separate from the UI language. The settings page allows selection from the currently supported gloss languages which, for now, is hard coded. A couple other changes are required:

- Remove gloss downloading from along side the Bible when the ui language is checked.
- Track the current gloss language in the gloss service, so we don't need to pass around the ui language in its functions
- Check if glosses are available in the reading view, and request to download if not available