### PR TITLE
Audio optimizations

### DIFF
--- a/lib/ui/home/audio/audio_player.dart
+++ b/lib/ui/home/audio/audio_player.dart
@@ -20,10 +20,8 @@ class BottomAudioPlayer extends StatelessWidget {
 
     return ListenableBuilder(
       listenable: viewModel,
-      builder: (buildContext, _) => AnimatedSlide(
-        offset: viewModel.isVisible ? Offset.zero : const Offset(0, 1),
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
+      builder: (buildContext, _) => _PlayerLauncher(
+        isVisible: viewModel.isVisible,
         child: Align(
           alignment: Alignment.bottomCenter,
           child: Container(
@@ -129,6 +127,30 @@ class BottomAudioPlayer extends StatelessWidget {
       ),
     );
   }
+}
+
+class _PlayerLauncher extends StatelessWidget {
+    final Widget child;
+    final bool isVisible;
+
+    const _PlayerLauncher({
+        required this.child,
+        required this.isVisible,
+    });
+
+    @override
+    Widget build(BuildContext context) {
+        if (!isVisible) {
+            return SizedBox.shrink();
+        }
+
+        return AnimatedSlide(
+            offset: Offset.zero,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+            child: child
+        );
+    }
 }
 
 // --- SUB-WIDGETS ---

--- a/lib/ui/home/audio/audio_player.dart
+++ b/lib/ui/home/audio/audio_player.dart
@@ -22,9 +22,7 @@ class BottomAudioPlayer extends StatelessWidget {
       listenable: viewModel,
       builder: (buildContext, _) => _PlayerLauncher(
         isVisible: viewModel.isVisible,
-        child: Align(
-          alignment: Alignment.bottomCenter,
-          child: Container(
+        child: Container(
             decoration: BoxDecoration(
               color: colorScheme.surfaceContainerHigh,
               boxShadow: [
@@ -124,7 +122,6 @@ class BottomAudioPlayer extends StatelessWidget {
             ),
           ),
         ),
-      ),
     );
   }
 }
@@ -144,7 +141,10 @@ class _PlayerLauncher extends StatelessWidget {
             offset: isVisible ? Offset.zero : Offset(0, 1),
             duration: const Duration(milliseconds: 300),
             curve: Curves.easeInOut,
-            child: isVisible ? child : SizedBox.shrink(),
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: isVisible ? child : SizedBox.shrink(),
+            )
         );
     }
 }

--- a/lib/ui/home/audio/audio_player.dart
+++ b/lib/ui/home/audio/audio_player.dart
@@ -140,15 +140,11 @@ class _PlayerLauncher extends StatelessWidget {
 
     @override
     Widget build(BuildContext context) {
-        if (!isVisible) {
-            return SizedBox.shrink();
-        }
-
         return AnimatedSlide(
-            offset: Offset.zero,
+            offset: isVisible ? Offset.zero : Offset(0, 1),
             duration: const Duration(milliseconds: 300),
             curve: Curves.easeInOut,
-            child: child
+            child: isVisible ? child : SizedBox.shrink(),
         );
     }
 }

--- a/lib/ui/home/audio/audio_player_view_model.dart
+++ b/lib/ui/home/audio/audio_player_view_model.dart
@@ -129,6 +129,8 @@ class AudioPlayerViewModel extends ChangeNotifier {
   }
 
   Future<void> changeRepeatMode(AudioRepeatModeType mode) async {
+    if (!isVisible) return;
+
     switch (mode) {
       case AudioRepeatModeType.none:
         setRepeatMode(AudioRepeatMode.none);
@@ -145,6 +147,8 @@ class AudioPlayerViewModel extends ChangeNotifier {
   }
 
   Future<void> changeSource(String source) async {
+    if (!isVisible) return;
+
     await _reload(source, reference.value);
   }
 
@@ -159,22 +163,32 @@ class AudioPlayerViewModel extends ChangeNotifier {
   }
 
   Future<void> play() async {
+    if (!isVisible) return;
+
     await player.play();
   }
 
   Future<void> pause() async {
+    if (!isVisible) return;
+
     await player.pause();
   }
 
   Future<void> seek(Duration position) async {
+    if (!isVisible) return;
+
     await player.seek(position);
   }
 
   Future<void> jumpTo(Reference reference) async {
+    if (!isVisible) return;
+
     await _reload(audioSource, reference);
   }
 
   Future<void> jumpToNext() async {
+    if (!isVisible) return;
+
     final reference = this.reference.value;
     if (reference == null) return;
 
@@ -189,6 +203,8 @@ class AudioPlayerViewModel extends ChangeNotifier {
   }
 
   Future<void> jumpToPrev() async {
+    if (!isVisible) return;
+
     final reference = this.reference.value;
     if (reference == null) return;
 


### PR DESCRIPTION
## Description

I was seeing two things in my recent audio changes:
1. The progress indicator was animating while the audio player was hidden and causing repaints of a significant chunk of the app.
2. Verse navigations cause audio view model to change state even when not visible

A couple changes to address this issue:
* The progress indicator is wrapped in a RepaintBoundary so that it doesn't cause other widgets to repaint
* A separate _PlayerLauncher widget that hides the player when not visible, so that it can't animate
* The audio view model blocks commands when not visible